### PR TITLE
Add Metadata API's to the `encore.dev` package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+<div align="center">
+  <a href="https://encore.dev" alt="encore"><img width="189px" src="https://encore.dev/assets/img/logo.svg"></a>
+  <h3><a href="https://encore.dev">Encore – The Backend Development Engine</a></h3>
+</div>
+
+# Encore Runtime API
+
+<div align="center">
+
+[![Go Reference](https://pkg.go.dev/badge/encore.dev.svg)](https://pkg.go.dev/encore.dev) [![Slack](https://img.shields.io/badge/chat-on%20slack-blue?style=flat-square&logo=slack)](https://encore.dev/slack) ![MPL-2 License](https://img.shields.io/github/license/encoredev/encore.dev?style=flat-square)
+
+</div>
+
+This repository contains the [Encore's](https://encore.dev) Runtime API contract, which Encore applications are built against.
+
+```bash
+go get -u encore.dev
+```
+
+When compiling your application the [encore compiler](https://github.com/encoredev/encore) will automatically provide an
+implementation of this API. [The default implementation can be found here](https://github.com/encoredev/encore/tree/main/runtime).

--- a/beta/auth/auth.go
+++ b/beta/auth/auth.go
@@ -1,3 +1,6 @@
+// Package auth provides the APIs to get information about the authenticated users.
+//
+// For more information about how authentication works with Encore applications see https://encore.dev/docs/develop/auth.
 package auth
 
 import "context"

--- a/beta/errs/error.go
+++ b/beta/errs/error.go
@@ -1,4 +1,6 @@
 // Package errs provides structured error handling for Encore applications.
+//
+// See https://encore.dev/docs/develop/errors for more information about how errors work within Encore applications.
 package errs
 
 import (

--- a/beta/package.go
+++ b/beta/package.go
@@ -1,0 +1,3 @@
+// Package beta contains packages which can be used in Encore applications, however their APIs are not stable
+// and may change in future releases.
+package beta

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -1,6 +1,6 @@
 // Package cron provides support for cron jobs: recurring tasks that run on a schedule.
 //
-// For more information about Encore's cron job support, see https://encore.dev/docs/cron-jobs.
+// For more information about Encore's cron job support, see https://encore.dev/docs/develop/cron-jobs.
 package cron
 
 // NewJob defines a new cron job. It is specially recognized by the Encore Parser

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,50 @@
+package encore_test
+
+import (
+	"fmt"
+	"time"
+
+	"encore.dev"
+)
+
+type Client interface{}
+
+var client Client
+
+func NewRedshiftClient() Client         { return nil }
+func NewBigQueryClient() Client         { return nil }
+func LocalFileWriter(dir string) Client { return nil }
+
+// Change the implementation of some code based on which cloud provider is being used.
+func ExampleMeta() {
+	switch encore.Meta().Environment.Cloud {
+	case encore.CloudAWS:
+		client = NewRedshiftClient()
+	case encore.CloudGCP:
+		client = NewBigQueryClient()
+	case encore.CloudLocal:
+		client = LocalFileWriter("/tmp/app-writes.txt")
+	default:
+		panic("unsupported cloud provider")
+	}
+}
+
+// Check if the application is running in production
+func ExampleMeta_2() {
+	if encore.Meta().Environment.Type != encore.EnvProduction {
+		fmt.Println("running in development")
+	} else {
+		fmt.Println("running in production")
+	}
+	// Output: running in development
+}
+
+func ExampleCurrentRequest() {
+	req := encore.CurrentRequest()
+	elapsed := time.Since(req.Started)
+
+	if req.Type == encore.APICall {
+		fmt.Printf("%s.%s has been running for %.3f seconds", req.Service, req.Endpoint, elapsed.Seconds())
+	}
+	// Output: myservice.api has been running for 0.543 seconds
+}

--- a/meta.go
+++ b/meta.go
@@ -1,0 +1,110 @@
+package encore
+
+import (
+	"net/url"
+	"time"
+)
+
+// Meta returns metadata about the running application.
+//
+// Meta will never return nil.
+func Meta() *AppMetadata {
+	panic("encore apps must be run using the encore command")
+}
+
+// AppMetadata contains metadata about the running Encore application.
+type AppMetadata struct {
+	// The application ID, if the application is not linked to the Encore platform this will be an empty string.
+	//
+	// To link to the Encore platform run `encore app link` from your terminal in the root directory of the Encore app.
+	AppID string
+
+	// The base URL which can be used to call the API of this running application.
+	//
+	// For local development it is "http://localhost:<port>", typically "http://localhost:4000".
+	//
+	// If a custom domain is used for this environment it is returned here, but note that
+	// changes only take effect at the time of deployment while custom domains can be updated at any time.
+	APIBaseURL url.URL
+
+	// Information about the environment the app is running in.
+	Environment EnvironmentMeta
+
+	// Information about the running binary itself.
+	Build BuildMeta
+
+	// Information about this deployment of the binary
+	Deploy DeployMeta
+}
+
+type EnvironmentMeta struct {
+	// The name of environment that this application.
+	// For local development it is "local".
+	Name string
+
+	// The type of environment is this application running in
+	// For local development this will be EnvLocal
+	Type EnvironmentType
+
+	// The cloud that this environment is running on
+	// For local development this is CloudLocal
+	Cloud CloudProvider
+}
+
+type BuildMeta struct {
+	// The git commit that formed the base of this build.
+	Revision string
+
+	// true if there were uncommitted changes on top of the Commit.
+	UncommittedChanges bool
+}
+
+type DeployMeta struct {
+	// The deployment ID created by the Encore Platform.
+	ID string
+
+	// The time the Encore Platform deployed this build to the environment.
+	Time time.Time
+}
+
+// EnvironmentType represents the type of environment.
+//
+// For more information on environment types see https://encore.dev/docs/deploy/environments#environment-types
+//
+// Additional environment types may be added in the future.
+type EnvironmentType string
+
+const (
+	// EnvProduction represents a production environment.
+	EnvProduction EnvironmentType = "production"
+
+	// EnvDevelopment represents a long-lived cloud-hosted, non-production environment, such as test environments.
+	EnvDevelopment EnvironmentType = "development"
+
+	// EnvEphemeral represents short-lived cloud-hosted, non-production environments, such as preview environments
+	// that only exist while a particular pull request is open.
+	EnvEphemeral EnvironmentType = "ephemeral"
+
+	// EnvLocal represents the local development environment when using 'encore run' or `encore test`.
+	EnvLocal EnvironmentType = "local"
+)
+
+// CloudProvider represents the cloud provider this application is running in.
+//
+// For more information about how Cloud Providers work with Encore, see https://encore.dev/docs/deploy/own-cloud
+//
+// Additional cloud providers may be added in the future.
+type CloudProvider string
+
+const (
+	CloudAWS   CloudProvider = "aws"
+	CloudGCP   CloudProvider = "gcp"
+	CloudAzure CloudProvider = "azure"
+
+	// EncoreCloud is Encore's own cloud offering, and the default provider for new Environments.
+	EncoreCloud CloudProvider = "encore"
+
+	// CloudLocal is used when an application is running from the Encore CLI by using either
+	// 'encore run' or 'encore test'
+	CloudLocal CloudProvider = "local"
+)

--- a/package.go
+++ b/package.go
@@ -1,0 +1,26 @@
+// Package encore provides the runtime API contract, which Encore applications are build against.
+//
+// Encore – The Backend Development Engine
+//
+// https://encore.dev
+//
+// Encore makes it incredibly simple to create distributed systems, backend services and APIs. While still deploying to
+// your own cloud account, Encore helps you escape the maze of cloud complexity:
+//
+// - No endless repetition of boilerplate.
+//
+// - No infrastructure to worry about.
+//
+// - No reinventing the wheel.
+//
+// Start building with a fantastic flow state experience that unlocks your creative potential.
+// All of this is freely available, based on the Open Source Encore Go Framework.
+//
+// For more information visit the website https://encore.dev or the documentation at https://encore.dev/docs.
+//
+//
+// Package encore
+//
+// This package provides the APIs for getting AppMetadata about the current application and the CurrentRequest.
+// For more information see http://encore.dev/docs/develop/metadata.
+package encore

--- a/request.go
+++ b/request.go
@@ -1,0 +1,60 @@
+package encore
+
+import (
+	"time"
+)
+
+// CurrentRequest returns the Request that is currently being handled by the calling goroutine
+//
+// It is safe for concurrent use and will return a new Request on each evocation, so can be mutated by the
+// calling code without impacting future calls.
+//
+// CurrentRequest never returns nil.
+func CurrentRequest() *Request {
+	panic("encore apps must be run using the encore command")
+}
+
+// Request provides metadata about how and why the currently running code was started.
+//
+// The current request can be returned by calling CurrentRequest()
+type Request struct {
+	Type    RequestType // What caused this request to start
+	Started time.Time   // What time the trigger occurred
+
+	// APICall specific parameters.
+	// These will be empty for operations with a type not APICall
+	Service    string     // Which service is processing this request
+	Endpoint   string     // Which API endpoint was called.
+	Path       string     // What was the path made to the API server.
+	PathParams PathParams // If there are path parameters, what are they?
+}
+
+// RequestType describes how the currently running code was triggered
+type RequestType string
+
+const (
+	None    RequestType = "none"     // There was no external trigger which caused this code to run. Most likely it was triggered by a package level init function.
+	APICall RequestType = "api-call" // The code was triggered via an API call to a service
+)
+
+// PathParams contains the path parameters parsed from the request path.
+// The ordering of the parameters in the path will be maintained from the URL.
+type PathParams []PathParam
+
+// PathParam represents a parsed path parameter.
+type PathParam struct {
+	Name  string // the name of the path parameter, without leading ':' or '*'.
+	Value string // the parsed path parameter value.
+}
+
+// Get returns the value of the path parameter with the given name.
+// If no such parameter exists it reports "".
+func (p PathParams) Get(name string) string {
+	for _, param := range p {
+		if param.Name == name {
+			return param.Value
+		}
+	}
+
+	return ""
+}

--- a/rlog/rlog.go
+++ b/rlog/rlog.go
@@ -1,3 +1,7 @@
+// Package rlog provides a simple logging interface which is integrated with Encore's
+// inbuilt distributed tracing.
+//
+// For more information about logging inside Encore applications see https://encore.dev/docs/observability/logging.
 package rlog
 
 // Debug logs a debug-level message.

--- a/storage/sqldb/sqldb.go
+++ b/storage/sqldb/sqldb.go
@@ -1,3 +1,6 @@
+// Package sqldb provides Encore services direct access to their databases.
+//
+// For the documentation on how to use databases within Encore see https://encore.dev/docs/develop/databases.
 package sqldb
 
 import (


### PR DESCRIPTION
This commit adds the new `CurrentRequest` and `Meta` API's to the `encore.dev`
package.

I've also taken the oppunity to improve the packages overall documentation by
adding package level documentation to all the packages within this repo, adding
a README and then adding two examples for the new API's.