### PR TITLE
Add PubSub APIs.

### DIFF
--- a/beta/auth/auth.go
+++ b/beta/auth/auth.go
@@ -3,7 +3,9 @@
 // For more information about how authentication works with Encore applications see https://encore.dev/docs/develop/auth.
 package auth
 
-import "context"
+import (
+	"context"
+)
 
 // UID is a unique identifier representing a user (a user id).
 type UID string

--- a/beta/errs/builder.go
+++ b/beta/errs/builder.go
@@ -9,35 +9,35 @@ type Builder struct {
 }
 
 // B is a shorthand for creating a new Builder.
-func B() *Builder { return &Builder{} }
+func B() *Builder { panic("encore apps must be run using the encore command") }
 
 // Code sets the error code.
-func (b *Builder) Code(c ErrCode) *Builder {
+func (*Builder) Code(c ErrCode) *Builder {
 	panic("encore apps must be run using the encore command")
 }
 
 // Msg sets the error message.
-func (b *Builder) Msg(msg string) *Builder {
+func (*Builder) Msg(msg string) *Builder {
 	panic("encore apps must be run using the encore command")
 }
 
 // Msgf is like Msg but uses fmt.Sprintf to construct the message.
-func (b *Builder) Msgf(format string, args ...interface{}) *Builder {
+func (*Builder) Msgf(format string, args ...interface{}) *Builder {
 	panic("encore apps must be run using the encore command")
 }
 
 // Meta appends metadata key-value pairs.
-func (b *Builder) Meta(metaPairs ...interface{}) *Builder {
+func (*Builder) Meta(metaPairs ...interface{}) *Builder {
 	panic("encore apps must be run using the encore command")
 }
 
 // Details sets the details.
-func (b *Builder) Details(det ErrDetails) *Builder {
+func (*Builder) Details(det ErrDetails) *Builder {
 	panic("encore apps must be run using the encore command")
 }
 
 // Cause sets the underlying error cause.
-func (b *Builder) Cause(err error) *Builder {
+func (*Builder) Cause(err error) *Builder {
 	panic("encore apps must be run using the encore command")
 }
 
@@ -49,6 +49,6 @@ func (b *Builder) Cause(err error) *Builder {
 //
 // If Msg has not been set and Cause is nil,
 // the Msg is set to "unknown error".
-func (b *Builder) Err() error {
+func (*Builder) Err() error {
 	panic("encore apps must be run using the encore command")
 }

--- a/beta/errs/codes.go
+++ b/beta/errs/codes.go
@@ -157,12 +157,14 @@ const (
 )
 
 // String returns the string representation of c.
+//
 func (c ErrCode) String() string {
 	return codeNames[c]
 }
 
 // HTTPStatus reports a suitable HTTP status code for an error, based on its code.
 // If err is nil it reports 200. If it's not an *Error it reports 500.
+//
 func (c ErrCode) HTTPStatus() int {
 	return codeStatus[c]
 }

--- a/beta/errs/error.go
+++ b/beta/errs/error.go
@@ -80,18 +80,18 @@ func Details(err error) ErrDetails {
 }
 
 // Error reports the error code and message.
-func (e *Error) Error() string {
+func (*Error) Error() string {
 	panic("encore apps must be run using the encore command")
 }
 
 // ErrorMessage reports the error message, joining this
 // error's message with the messages from any underlying errors.
-func (e *Error) ErrorMessage() string {
+func (*Error) ErrorMessage() string {
 	panic("encore apps must be run using the encore command")
 }
 
 // Unwrap returns the underlying error, if any.
-func (e *Error) Unwrap() error {
+func (*Error) Unwrap() error {
 	panic("encore apps must be run using the encore command")
 }
 
@@ -99,7 +99,7 @@ func (e *Error) Unwrap() error {
 // The status code is computed with HTTPStatus.
 //
 // If err is nil it writes:
-// 	{"code": "ok", "message": "", "details": null}
+//     {"code": "ok", "message": "", "details": null}
 func HTTPError(w http.ResponseWriter, err error) {
 	panic("encore apps must be run using the encore command")
 }

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -12,6 +12,9 @@ package cron
 // refactor the code and move the cron job definition to another package, Encore uses
 // this ID to keep track that it's the same cron job and not a different one.
 //
+// The ID must be defined in kebab-case, be no longer than 63 characters, start with
+// a letter and end with either a letter or number.
+//
 // The fields provided in the JobConfig must be constant literals, as they are parsed
 // directly by the Encore Platform and are not actually executed at runtime.
 //
@@ -48,7 +51,7 @@ type JobConfig struct {
 	// Endpoint is the Encore API endpoint that should be called when the cron job executes.
 	// It must not take any parameters other than context.Conetxt; that is, its signature must be
 	// either "func(context.Context) error" or "func(context.Context) (T, error)" for any type T.
-	Endpoint interface{}
+	Endpoint any
 
 	// Every defines how often the cron job should execute.
 	// You must either specify either Every or Schedule (but not both).

--- a/et/package.go
+++ b/et/package.go
@@ -1,0 +1,3 @@
+// Package et stands for Encore Tests and provides a number of functions and tools for writing fully integrated
+// test suites for Encore applications.
+package et

--- a/et/pubsub.go
+++ b/et/pubsub.go
@@ -1,0 +1,20 @@
+package et
+
+import (
+	"encore.dev/pubsub"
+)
+
+// Topic returns a TopicHelper for the given topic.
+func Topic[T any](topic *pubsub.Topic[T]) TopicHelpers[T] {
+	panic("encore apps must be run using the encore command")
+}
+
+// TopicHelpers provides functions for interacting with the backing topic implementation
+// during unit tests. It is designed to help test code that uses the pubsub.Topic
+//
+// Note all functions on this TopicHelpers are scoped to the current test
+// and will only impact and observe state from the current test
+type TopicHelpers[T any] interface {
+	// PublishedMessages returns a slice of all messages published during this test on this topic.
+	PublishedMessages() []T
+}

--- a/pubsub/package.go
+++ b/pubsub/package.go
@@ -1,0 +1,5 @@
+// Package pubsub provides Encore applications with the ability to create Topics and multilpe Subscriptions on those
+// topics in a cloud-agnostic manner.
+//
+// For more information see http://encore.dev/docs/develop/pubsub
+package pubsub

--- a/pubsub/subscription.go
+++ b/pubsub/subscription.go
@@ -1,0 +1,45 @@
+package pubsub
+
+// Subscription represents a subscription to a Topic.
+type Subscription[T any] struct {
+	_ int // for godoc to show unexported fields
+}
+
+// NewSubscription is used to declare a Subscription to a topic. The passed in handler will be called
+// for each message published to the topic.
+//
+// A call to NewSubscription can only be made when declaring a package level variable. Any
+// calls to this function made outside a package level variable declaration will result
+// in a compiler error.
+//
+// The subscription name must be unique for that topic. Subscription names must be defined
+// in kebab-case (lowercase alphanumerics and hyphen seperated). The subscription name must start with a letter
+// and end with either a letter or number. It cannot be longer than 63 characters.
+//
+// Once created and deployed never change the subscription name, or the topic name otherwise messages will be lost which
+// could be in flight.
+//
+// Example:
+//
+//     import "encore.dev/pubsub"
+//
+//     type MyEvent struct {
+//       Foo string
+//     }
+//
+//     var MyTopic = pubsub.NewTopic[*MyEvent]("my-topic", pubsub.TopicConfig{
+//       DeliveryGuarantee: pubsub.AtLeastOnce,
+//     })
+//
+//     var Subscription = pubsub.NewSubscription(MyTopic, "my-subscription", pubsub.SubscriptionConfig[*MyEvent]{
+//       Handler:     HandleEvent,
+//       RetryPolicy: &pubsub.RetryPolicy { MaxRetries: 10 },
+//     })
+//
+//     func HandleEvent(ctx context.Context, event *MyEvent) error {
+//       rlog.Info("received foo")
+//       return nil
+//     }
+func NewSubscription[T any](topic *Topic[T], name string, subscriptionCfg SubscriptionConfig[T]) *Subscription[T] {
+	panic("encore apps must be run using the encore command")
+}

--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -1,0 +1,63 @@
+package pubsub
+
+import (
+	"context"
+)
+
+// Topic presents a flow of events of type T from any number of publishers to
+// any number of subscribers.
+//
+// Each subscription will receive a copy of each message published to the topic.
+//
+// See NewTopic for more information on how to declare a Topic.
+type Topic[T any] struct {
+	_ int // for godoc to show unexported fields
+}
+
+// NewTopic is used to declare a Topic. Encore will use static
+// analysis to identify Topics and automatically provision them
+// for you.
+//
+// A call to NewTopic can only be made when declaring a package level variable. Any
+// calls to this function made outside a package level variable declaration will result
+// in a compiler error.
+//
+// The topic name must be unique within an Encore application. Topic names must be defined
+// in kebab-case (lowercase alphanumerics and hyphen seperated). The topic name must start with a letter
+// and end with either a letter or number. It cannot be longer than 63 characters. Once created and deployed never
+// change the topic name. When refactoring the topic name must stay the same.
+// This allows for messages already on the topic to continue to be received after the refactored
+// code is deployed.
+//
+// Example:
+//
+//     import "encore.dev/pubsub"
+//
+//     type MyEvent struct {
+//       Foo string
+//     }
+//
+//     var MyTopic = pubsub.NewTopic[*MyEvent]("my-topic", pubsub.TopicConfig{
+//       DeliveryGuarantee: pubsub.AtLeastOnce,
+//     })
+//
+//    //encore:api public
+//    func DoFoo(ctx context.Context) error {
+//      msgID, err := MyTopic.Publish(ctx, &MyEvent{Foo: "bar"})
+//      if err != nil { return err }
+//      rlog.Info("foo published", "message_id", msgID)
+//      return nil
+//    }
+func NewTopic[T any](name string, cfg TopicConfig) *Topic[T] {
+	panic("encore apps must be run using the encore command")
+}
+
+// Publish will publish a message to the topic and returns a unique message ID for the message.
+//
+// This function will not return until the message has been successfully accepted by the topic.
+//
+// If an error is returned, it is probable that the message failed to be published, however it is possible
+// that the message could still be received by subscriptions to the topic.
+func (*Topic[T]) Publish(ctx context.Context, msg T) (id string, err error) {
+	panic("encore apps must be run using the encore command")
+}

--- a/pubsub/types.go
+++ b/pubsub/types.go
@@ -1,0 +1,98 @@
+package pubsub
+
+import (
+	"context"
+	"time"
+)
+
+// SubscriptionConfig is used when creating a subscription
+//
+// The values given here may be clamped to the supported values by
+// the target cloud. (i.e. ack deadline may be brought within the supported range
+// by the target cloud pubsub implementation).
+type SubscriptionConfig[T any] struct {
+	// The function which will be called to process a message
+	// sent on the topic.
+	//
+	// It is important for this function to block and not return
+	// until all processing relating to the message has been completed.
+	//
+	// When this function returns a `nil`, the message will be
+	// acknowledged (acked) from the topic, and should not be redelivered.
+	//
+	// When this function returns an `error`, the message will be
+	// negatively acknowledged (nacked), which will cause a redelivery
+	// attempt to be made (unless the retry policy's MaxRetries has been reached).
+	//
+	// This field is required.
+	Handler func(ctx context.Context, msg T) error
+
+	// AckDeadline is the time a consumer has to process a message
+	// before it's returned to the subscription
+	//
+	// Default is 30 seconds, however the ack deadline must be at least
+	// 1 second.
+	AckDeadline time.Duration
+
+	// MessageRetention is how long an undelivered message is kept
+	// on the topic before it's purged
+	// Default is 7 days.
+	MessageRetention time.Duration
+
+	// RetryPolicy defines how a message should be retried when
+	// the subscriber returns an error
+	RetryPolicy *RetryPolicy
+}
+
+// RetryPolicy defines how a subscription should handle retries
+// after errors either delivering the message or processing the message.
+//
+// The values given to this structure are parsed at compile time, such that
+// the correct Cloud resources can be provisioned to support the queue.
+//
+// As such the values given here may be clamped to the supported values by
+// the target cloud. (i.e. min/max values brought within the supported range
+// by the target cloud).
+type RetryPolicy struct {
+	// The minimum time to wait between retries. Defaults to 10 seconds.
+	MinBackoff time.Duration
+
+	// The maximum time to wait between retries. Defaults to 10 minutes.
+	MaxBackoff time.Duration
+
+	// MaxRetries is used to control deadletter queuing logic, when:
+	//   n == 0: A default value of 100 retries will be used
+	//   n > 0:  Encore will forward a message to a dead letter queue after n retries
+	//   n == pubsub.InfiniteRetries: Messages will not be forwarded to the dead letter queue by the Encore framework
+	MaxRetries int
+}
+
+const ( // NoRetries is used to control deadletter queuing logic, when set as the MaxRetires within the RetryPolicy
+	// it will attempt to immediately forward a message to the dead letter queue if the subscription Handler
+	// returns any error or panics.
+	//
+	// Note: With some cloud providers, having no retries may not be supported, in which case the minimum number of
+	// retries permitted by the provider will be used.
+	NoRetries = -2 // InfiniteRetries is used to control deadletter queuing logic, when set as the MaxRetires within the RetryPolicy
+	// it will attempt to always retry a message without ever sending it to the dead letter queue.
+	//
+	// Note: With some cloud providers, infinite retries may not be supported, in which case the maximum number of
+	// retries permitted by the provider will be used.
+	InfiniteRetries = -1
+)
+
+// DeliveryGuarantee is used to configure the delivery contract for a topic
+type DeliveryGuarantee int
+
+const ( // AtLeastOnce guarantees that a message for a subscription is delivered to
+	// a consumer at least once. This is supported by all cloud providers.
+	AtLeastOnce DeliveryGuarantee = iota + 1
+)
+
+// TopicConfig is used when creating a Topic
+type TopicConfig struct {
+	// DeliveryGuarantee is used to configure the delivery guarantee of a Topic
+	//
+	// This field is required.
+	DeliveryGuarantee DeliveryGuarantee
+}

--- a/request.go
+++ b/request.go
@@ -49,12 +49,6 @@ type PathParam struct {
 
 // Get returns the value of the path parameter with the given name.
 // If no such parameter exists it reports "".
-func (p PathParams) Get(name string) string {
-	for _, param := range p {
-		if param.Name == name {
-			return param.Value
-		}
-	}
-
-	return ""
+func (PathParams) Get(name string) string {
+	panic("encore apps must be run using the encore command")
 }

--- a/rlog/rlog.go
+++ b/rlog/rlog.go
@@ -24,7 +24,9 @@ func Error(msg string, keysAndValues ...interface{}) {
 
 // Ctx holds additional logging context for use with the Infoc and family
 // of logging functions.
-type Ctx struct{}
+type Ctx struct {
+	_ int // for godoc to show unexported fields
+}
 
 // With adds a variadic number of fields to the logging context.
 // The keysAndValues must be pairs of string keys and arbitrary data.
@@ -35,27 +37,27 @@ func With(keysAndValues ...interface{}) Ctx {
 // With creates a new logging context that inherits the context
 // from the original ctx and adds additional context on top.
 // The original ctx is not affected.
-func (ctx Ctx) With(keysAndValues ...interface{}) Ctx {
+func (Ctx) With(keysAndValues ...interface{}) Ctx {
 	panic("encore apps must be run using the encore command")
 }
 
 // Debug logs a debug-level message, merging the context from ctx
 // with the additional context provided as key-value pairs.
 // The variadic key-value pairs are treated as they are in With.
-func (ctx Ctx) Debug(msg string, keysAndValues ...interface{}) {
+func (Ctx) Debug(msg string, keysAndValues ...interface{}) {
 	panic("encore apps must be run using the encore command")
 }
 
 // Info logs an info-level message, merging the context from ctx
 // with the additional context provided as key-value pairs.
 // The variadic key-value pairs are treated as they are in With.
-func (ctx Ctx) Info(msg string, keysAndValues ...interface{}) {
+func (Ctx) Info(msg string, keysAndValues ...interface{}) {
 	panic("encore apps must be run using the encore command")
 }
 
 // Error logs an error-level message, merging the context from ctx
 // with the additional context provided as key-value pairs.
 // The variadic key-value pairs are treated as they are in With.
-func (ctx Ctx) Error(msg string, keysAndValues ...interface{}) {
+func (Ctx) Error(msg string, keysAndValues ...interface{}) {
 	panic("encore apps must be run using the encore command")
 }

--- a/storage/sqldb/sqldb.go
+++ b/storage/sqldb/sqldb.go
@@ -46,7 +46,9 @@ func QueryRow(ctx context.Context, query string, args ...interface{}) *Row {
 // Tx is a handle to a database transaction.
 //
 // See *database/sql.Tx for additional documentation.
-type Tx struct{}
+type Tx struct {
+	_ int // for godoc to show unexported fields
+}
 
 // Begin opens a new database transaction.
 //
@@ -134,14 +136,14 @@ func QueryRowTx(tx *Tx, ctx context.Context, query string, args ...interface{}) 
 // of the result set. Use Next to advance from row to row.
 //
 // See *database/sql.Rows for additional documentation.
-type Rows struct{}
+type Rows struct {
+	_ int // for godoc to show unexported fields
+}
 
 // Close closes the Rows, preventing further enumeration.
 //
 // See (*database/sql.Rows).Close() for additional documentation.
-func (*Rows) Close() error {
-	panic("encore apps must be run using the encore command")
-}
+func (*Rows) Close() { panic("encore apps must be run using the encore command") }
 
 // Scan copies the columns in the current row into the values pointed
 // at by dest. The number of values in dest must be the same as the
@@ -156,9 +158,7 @@ func (*Rows) Scan(dest ...interface{}) error {
 // Err may be called after an explicit or implicit Close.
 //
 // See (*database/sql.Rows).Err() for additional documentation.
-func (*Rows) Err() error {
-	panic("encore apps must be run using the encore command")
-}
+func (*Rows) Err() error { panic("encore apps must be run using the encore command") }
 
 // Next prepares the next result row for reading with the Scan method. It
 // returns true on success, or false if there is no next result row or an error
@@ -168,14 +168,14 @@ func (*Rows) Err() error {
 // Every call to Scan, even the first one, must be preceded by a call to Next.
 //
 // See (*database/sql.Rows).Next() for additional documentation.
-func (*Rows) Next() bool {
-	panic("encore apps must be run using the encore command")
-}
+func (*Rows) Next() bool { panic("encore apps must be run using the encore command") }
 
 // Row is the result of calling QueryRow to select a single row.
 //
 // See *database/sql.Row for additional documentation.
-type Row struct{}
+type Row struct {
+	_ int // for godoc to show unexported fields
+}
 
 // Scan copies the columns from the matched row into the values
 // pointed at by dest.
@@ -185,8 +185,9 @@ func (*Row) Scan(dest ...interface{}) error {
 	panic("encore apps must be run using the encore command")
 }
 
-// constStr is a string that can only be provided as a constant.
-type constStr string
+func (*Row) Err() error {
+	panic("encore apps must be run using the encore command")
+}
 
 // Named returns a database object connected to the database with the given name.
 //
@@ -195,10 +196,8 @@ func Named(name constStr) *Database {
 	panic("encore apps must be run using the encore command")
 }
 
-type Database struct{}
-
-func (*Database) Begin(ctx context.Context) (*Tx, error) {
-	panic("encore apps must be run using the encore command")
+type Database struct {
+	_ int // for godoc to show unexported fields
 }
 
 func (*Database) Exec(ctx context.Context, query string, args ...interface{}) (ExecResult, error) {
@@ -210,6 +209,10 @@ func (*Database) Query(ctx context.Context, query string, args ...interface{}) (
 }
 
 func (*Database) QueryRow(ctx context.Context, query string, args ...interface{}) *Row {
+	panic("encore apps must be run using the encore command")
+}
+
+func (*Database) Begin(ctx context.Context) (*Tx, error) {
 	panic("encore apps must be run using the encore command")
 }
 


### PR DESCRIPTION
This commit adds the new API's for the `pubsub`
and `et` (Encore Testing) packages.

It was auto generated using `encr.dev/tools/publicapigen`
from the [Encore runtime](https://github.com/encoredev/encore/tree/main/runtime)
and is the first time the tool has been used, so all other changes in this commit
are the result of the formatting of the public api generator.