### PR TITLE
storage/sqldb/sqldb: add missing type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module encore.dev
 
-go 1.13
+go 1.18

--- a/storage/sqldb/sqldb.go
+++ b/storage/sqldb/sqldb.go
@@ -189,6 +189,10 @@ func (*Row) Err() error {
 	panic("encore apps must be run using the encore command")
 }
 
+// constStr is a string that can only be provided as a constant.
+//
+type constStr string
+
 // Named returns a database object connected to the database with the given name.
 //
 // The name must be a string literal constant, to facilitate static analysis.


### PR DESCRIPTION
Add the missing constStr type and bump the required go version
to 1.18 so the package compiles with plain `go build`.
