### PR TITLE
[ENC-921] Add Config API's to public contract

### DIFF
--- a/beta/auth/auth.go
+++ b/beta/auth/auth.go
@@ -23,5 +23,11 @@ type UID string
 // API calls made with these options will not be made and will immediately return
 // a client-side error.
 func WithContext(ctx context.Context, uid UID, data interface{}) context.Context {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/auth/auth.go#L53-L57
 	panic("encore apps must be run using the encore command")
 }

--- a/beta/auth/pkgfn.go
+++ b/beta/auth/pkgfn.go
@@ -4,6 +4,12 @@ package auth
 // The second result is true if there is a user and false
 // if the request was made without authentication details.
 func UserID() (UID, bool) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/auth/pkgfn.go#L11-L13
 	panic("encore apps must be run using the encore command")
 }
 
@@ -16,5 +22,11 @@ func UserID() (UID, bool) {
 //	usr, ok := auth.Data().(*user.Data)
 //	if !ok { /* ... */ }
 func Data() any {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/auth/pkgfn.go#L24-L26
 	panic("encore apps must be run using the encore command")
 }

--- a/beta/errs/builder.go
+++ b/beta/errs/builder.go
@@ -9,35 +9,80 @@ type Builder struct {
 }
 
 // B is a shorthand for creating a new Builder.
-func B() *Builder { panic("encore apps must be run using the encore command") }
+func B() *Builder {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//
+	//	https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/builder.go#L25-L25
+	panic("encore apps must be run using the encore command")
+}
 
 // Code sets the error code.
 func (*Builder) Code(c ErrCode) *Builder {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/builder.go#L28-L32
 	panic("encore apps must be run using the encore command")
 }
 
 // Msg sets the error message.
 func (*Builder) Msg(msg string) *Builder {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/builder.go#L35-L38
 	panic("encore apps must be run using the encore command")
 }
 
 // Msgf is like Msg but uses fmt.Sprintf to construct the message.
 func (*Builder) Msgf(format string, args ...interface{}) *Builder {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/builder.go#L41-L44
 	panic("encore apps must be run using the encore command")
 }
 
 // Meta appends metadata key-value pairs.
 func (*Builder) Meta(metaPairs ...interface{}) *Builder {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/builder.go#L47-L50
 	panic("encore apps must be run using the encore command")
 }
 
 // Details sets the details.
 func (*Builder) Details(det ErrDetails) *Builder {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/builder.go#L53-L57
 	panic("encore apps must be run using the encore command")
 }
 
 // Cause sets the underlying error cause.
 func (*Builder) Cause(err error) *Builder {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/builder.go#L60-L71
 	panic("encore apps must be run using the encore command")
 }
 
@@ -50,5 +95,11 @@ func (*Builder) Cause(err error) *Builder {
 // If Msg has not been set and Cause is nil,
 // the Msg is set to "unknown error".
 func (*Builder) Err() error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/builder.go#L81-L109
 	panic("encore apps must be run using the encore command")
 }

--- a/beta/errs/error.go
+++ b/beta/errs/error.go
@@ -44,12 +44,24 @@ type Metadata map[string]interface{}
 // If err is already an *Error its code, message, and details
 // are copied over to the new error.
 func Wrap(err error, msg string, metaPairs ...interface{}) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/error.go#L66-L82
 	panic("encore apps must be run using the encore command")
 }
 
 // WrapCode is like Wrap but also sets the error code.
 // If code is OK it reports nil.
 func WrapCode(err error, code ErrCode, msg string, metaPairs ...interface{}) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/error.go#L86-L102
 	panic("encore apps must be run using the encore command")
 }
 
@@ -57,6 +69,12 @@ func WrapCode(err error, code ErrCode, msg string, metaPairs ...interface{}) err
 // If the error is already an *Error it returns it unmodified.
 // If err is nil it returns nil.
 func Convert(err error) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/error.go#L107-L118
 	panic("encore apps must be run using the encore command")
 }
 
@@ -64,34 +82,70 @@ func Convert(err error) error {
 // If err is nil it reports OK.
 // Otherwise if err is not an *Error it reports Unknown.
 func Code(err error) ErrCode {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/error.go#L123-L130
 	panic("encore apps must be run using the encore command")
 }
 
 // Meta reports the metadata included in the error.
 // If err is nil or the error lacks metadata it reports nil.
 func Meta(err error) Metadata {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/error.go#L134-L139
 	panic("encore apps must be run using the encore command")
 }
 
 // Details reports the error details included in the error.
 // If err is nil or the error lacks details it reports nil.
 func Details(err error) ErrDetails {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/error.go#L143-L148
 	panic("encore apps must be run using the encore command")
 }
 
 // Error reports the error code and message.
 func (*Error) Error() string {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/error.go#L151-L153
 	panic("encore apps must be run using the encore command")
 }
 
 // ErrorMessage reports the error message, joining this
 // error's message with the messages from any underlying errors.
 func (*Error) ErrorMessage() string {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/error.go#L157-L181
 	panic("encore apps must be run using the encore command")
 }
 
 // Unwrap returns the underlying error, if any.
 func (*Error) Unwrap() error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/error.go#L184-L186
 	panic("encore apps must be run using the encore command")
 }
 
@@ -102,5 +156,11 @@ func (*Error) Unwrap() error {
 //
 //	{"code": "ok", "message": "", "details": null}
 func HTTPError(w http.ResponseWriter, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/beta/errs/error.go#L193-L195
 	panic("encore apps must be run using the encore command")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,20 @@
+// Package config provides a simple way to access configuration values for a
+// service using the Load function.
+//
+// # By default configuration is pulled at build time from CUE files in each service directory
+//
+// For more information about configuration see https://encore.dev/docs/develop/config.
+package config
+
+// Load returns the fully loaded configuration for this service.
+//
+// Note: This function can only be called from within services.
+func Load[T any]() T {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/config/config.go#L32-L52
+	panic("encore apps must be run using the encore command")
+}

--- a/config/types.go
+++ b/config/types.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"time"
+
+	"encore.dev/types/uuid"
+)
+
+// Value represents a value in the configuration for this application
+// which can be any value represented in the configuration files.
+//
+// It is a function because the underlying value could change while
+// the application is still running due to unit tests providing
+// overrides to test different behaviours.
+type Value[T any] func() T
+
+// Values represents a list of values in the configuration for this
+// application which can be any value represented in the configuration files.
+//
+// It is a function because the underlying value could change while
+// the application is still running due to unit tests providing
+// overrides to test different behaviours.
+type Values[T any] func() []T
+
+type Bool = Value[bool]
+type Int8 = Value[int8]
+type Int16 = Value[int16]
+type Int32 = Value[int32]
+type Int64 = Value[int64]
+type UInt8 = Value[uint8]
+type UInt16 = Value[uint16]
+type UInt32 = Value[uint32]
+type UInt64 = Value[uint64]
+type Float32 = Value[float32]
+type Float64 = Value[float64]
+type String = Value[string]
+type Bytes = Value[[]byte]
+type Time = Value[time.Time]
+type UUID = Value[uuid.UUID]
+type Int = Value[int]
+type UInt = Value[uint]

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -37,6 +37,12 @@ package cron
 //		return nil
 //	}
 func NewJob(id string, jobConfig JobConfig) *Job {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/cron/cron.go#L39-L47
 	panic("encore apps must be run using the encore command")
 }
 

--- a/et/pubsub.go
+++ b/et/pubsub.go
@@ -6,6 +6,12 @@ import (
 
 // Topic returns a TopicHelper for the given topic.
 func Topic[T any](topic *pubsub.Topic[T]) TopicHelpers[T] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/et/pubsub.go#L8-L10
 	panic("encore apps must be run using the encore command")
 }
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -41,16 +41,34 @@ type Request struct {
 
 // WithContext returns a new Request with the context set to ctx.
 func (*Request) WithContext(ctx context.Context) Request {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/middleware/middleware.go#L44-L48
 	panic("encore apps must be run using the encore command")
 }
 
 // Context reports the request's context.
 func (*Request) Context() context.Context {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/middleware/middleware.go#L51-L53
 	panic("encore apps must be run using the encore command")
 }
 
 // Data returns information about the request.
 func (*Request) Data() *encore.Request {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/middleware/middleware.go#L56-L58
 	panic("encore apps must be run using the encore command")
 }
 
@@ -94,5 +112,11 @@ type Response struct {
 // NewRequest constructs a new Request that returns the given context and request data.
 // It is primarily used for testing middleware.
 func NewRequest(ctx context.Context, data *encore.Request) Request {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/middleware/middleware.go#L99-L104
 	panic("encore apps must be run using the encore command")
 }

--- a/pkgfn.go
+++ b/pkgfn.go
@@ -4,6 +4,12 @@ package encore
 //
 // Meta will never return nil.
 func Meta() *AppMetadata {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/pkgfn.go#L11-L13
 	panic("encore apps must be run using the encore command")
 }
 
@@ -14,5 +20,11 @@ func Meta() *AppMetadata {
 //
 // CurrentRequest never returns nil.
 func CurrentRequest() *Request {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/pkgfn.go#L21-L23
 	panic("encore apps must be run using the encore command")
 }

--- a/pubsub/pkgfn.go
+++ b/pubsub/pkgfn.go
@@ -35,5 +35,11 @@ package pubsub
 //	  return nil
 //	}
 func NewTopic[T any](name string, cfg TopicConfig) *Topic[T] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/pubsub/pkgfn.go#L42-L44
 	panic("encore apps must be run using the encore command")
 }

--- a/pubsub/subscription.go
+++ b/pubsub/subscription.go
@@ -41,5 +41,11 @@ type Subscription[T any] struct {
 //	  return nil
 //	}
 func NewSubscription[T any](topic *Topic[T], name string, subscriptionCfg SubscriptionConfig[T]) *Subscription[T] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/pubsub/subscription.go#L54-L180
 	panic("encore apps must be run using the encore command")
 }

--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -21,5 +21,11 @@ type Topic[T any] struct {
 // If an error is returned, it is probable that the message failed to be published, however it is possible
 // that the message could still be received by subscriptions to the topic.
 func (*Topic[T]) Publish(ctx context.Context, msg T) (id string, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/pubsub/topic.go#L66-L103
 	panic("encore apps must be run using the encore command")
 }

--- a/request.go
+++ b/request.go
@@ -61,5 +61,11 @@ type PathParam struct {
 // Get returns the value of the path parameter with the given name.
 // If no such parameter exists it reports "".
 func (PathParams) Get(name string) string {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/request.go#L67-L75
 	panic("encore apps must be run using the encore command")
 }

--- a/rlog/pkgfn.go
+++ b/rlog/pkgfn.go
@@ -3,23 +3,47 @@ package rlog
 // Debug logs a debug-level message.
 // The variadic key-value pairs are treated as they are in With.
 func Debug(msg string, keysAndValues ...interface{}) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/rlog/pkgfn.go#L10-L12
 	panic("encore apps must be run using the encore command")
 }
 
 // Info logs an info-level message.
 // The variadic key-value pairs are treated as they are in With.
 func Info(msg string, keysAndValues ...interface{}) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/rlog/pkgfn.go#L16-L18
 	panic("encore apps must be run using the encore command")
 }
 
 // Error logs an error-level message.
 // The variadic key-value pairs are treated as they are in With.
 func Error(msg string, keysAndValues ...interface{}) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/rlog/pkgfn.go#L22-L24
 	panic("encore apps must be run using the encore command")
 }
 
 // With adds a variadic number of fields to the logging context.
 // The keysAndValues must be pairs of string keys and arbitrary data.
 func With(keysAndValues ...interface{}) Ctx {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/rlog/pkgfn.go#L28-L30
 	panic("encore apps must be run using the encore command")
 }

--- a/rlog/rlog.go
+++ b/rlog/rlog.go
@@ -14,6 +14,12 @@ type Ctx struct {
 // with the additional context provided as key-value pairs.
 // The variadic key-value pairs are treated as they are in With.
 func (Ctx) Debug(msg string, keysAndValues ...interface{}) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/rlog/rlog.go#L62-L65
 	panic("encore apps must be run using the encore command")
 }
 
@@ -21,6 +27,12 @@ func (Ctx) Debug(msg string, keysAndValues ...interface{}) {
 // with the additional context provided as key-value pairs.
 // The variadic key-value pairs are treated as they are in With.
 func (Ctx) Info(msg string, keysAndValues ...interface{}) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/rlog/rlog.go#L70-L73
 	panic("encore apps must be run using the encore command")
 }
 
@@ -28,6 +40,12 @@ func (Ctx) Info(msg string, keysAndValues ...interface{}) {
 // with the additional context provided as key-value pairs.
 // The variadic key-value pairs are treated as they are in With.
 func (Ctx) Error(msg string, keysAndValues ...interface{}) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/rlog/rlog.go#L78-L81
 	panic("encore apps must be run using the encore command")
 }
 
@@ -35,5 +53,11 @@ func (Ctx) Error(msg string, keysAndValues ...interface{}) {
 // from the original ctx and adds additional context on top.
 // The original ctx is not affected.
 func (Ctx) With(keysAndValues ...interface{}) Ctx {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/rlog/rlog.go#L86-L94
 	panic("encore apps must be run using the encore command")
 }

--- a/storage/cache/basic.go
+++ b/storage/cache/basic.go
@@ -9,6 +9,12 @@ import (
 // The type parameter K specifies the key type, which can either be a
 // named struct type or a basic type (string, int, etc).
 func NewStringKeyspace[K any](cluster *Cluster, cfg KeyspaceConfig) *StringKeyspace[K] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L16-L25
 	panic("encore apps must be run using the encore command")
 }
 
@@ -22,6 +28,12 @@ type StringKeyspace[K any] struct {
 //
 // See https://redis.io/commands/get/ for more information.
 func (*StringKeyspace[K]) Get(ctx context.Context, key K) (string, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L36-L38
 	panic("encore apps must be run using the encore command")
 }
 
@@ -29,6 +41,12 @@ func (*StringKeyspace[K]) Get(ctx context.Context, key K) (string, error) {
 //
 // See https://redis.io/commands/set/ for more information.
 func (*StringKeyspace[K]) Set(ctx context.Context, key K, val string) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L43-L45
 	panic("encore apps must be run using the encore command")
 }
 
@@ -37,6 +55,12 @@ func (*StringKeyspace[K]) Set(ctx context.Context, key K, val string) error {
 //
 // See https://redis.io/commands/setnx/ for more information.
 func (*StringKeyspace[K]) SetIfNotExists(ctx context.Context, key K, val string) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L51-L53
 	panic("encore apps must be run using the encore command")
 }
 
@@ -45,6 +69,12 @@ func (*StringKeyspace[K]) SetIfNotExists(ctx context.Context, key K, val string)
 //
 // See https://redis.io/commands/set/ for more information.
 func (*StringKeyspace[K]) Replace(ctx context.Context, key K, val string) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L59-L61
 	panic("encore apps must be run using the encore command")
 }
 
@@ -53,6 +83,12 @@ func (*StringKeyspace[K]) Replace(ctx context.Context, key K, val string) error 
 //
 // See https://redis.io/commands/getset/ for more information.
 func (*StringKeyspace[K]) GetAndSet(ctx context.Context, key K, val string) (oldVal string, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L67-L69
 	panic("encore apps must be run using the encore command")
 }
 
@@ -61,6 +97,12 @@ func (*StringKeyspace[K]) GetAndSet(ctx context.Context, key K, val string) (old
 //
 // See https://redis.io/commands/getdel/ for more information.
 func (*StringKeyspace[K]) GetAndDelete(ctx context.Context, key K) (oldVal string, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L75-L77
 	panic("encore apps must be run using the encore command")
 }
 
@@ -72,6 +114,12 @@ func (*StringKeyspace[K]) GetAndDelete(ctx context.Context, key K) (oldVal strin
 //
 // See https://redis.io/commands/del/ for more information.
 func (*StringKeyspace[K]) Delete(ctx context.Context, keys ...K) (deleted int, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L86-L88
 	panic("encore apps must be run using the encore command")
 }
 
@@ -82,6 +130,12 @@ func (*StringKeyspace[K]) Delete(ctx context.Context, keys ...K) (deleted int, e
 //
 //	myKeyspace.With(cache.ExpireIn(3 * time.Second)).Set(...)
 func (*StringKeyspace[K]) With(opts ...WriteOption) *StringKeyspace[K] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L95-L97
 	panic("encore apps must be run using the encore command")
 }
 
@@ -94,6 +148,12 @@ func (*StringKeyspace[K]) With(opts ...WriteOption) *StringKeyspace[K] {
 //
 // See https://redis.io/commands/append/ for more information.
 func (*StringKeyspace[K]) Append(ctx context.Context, key K, val string) (newLen int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L107-L120
 	panic("encore apps must be run using the encore command")
 }
 
@@ -110,6 +170,12 @@ func (*StringKeyspace[K]) Append(ctx context.Context, key K, val string) (newLen
 //
 // See https://redis.io/commands/setrange/ for more information.
 func (*StringKeyspace[K]) GetRange(ctx context.Context, key K, from, to int64) (val string, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L134-L145
 	panic("encore apps must be run using the encore command")
 }
 
@@ -124,6 +190,12 @@ func (*StringKeyspace[K]) GetRange(ctx context.Context, key K, from, to int64) (
 //
 // See https://redis.io/commands/setrange/ for more information.
 func (*StringKeyspace[K]) SetRange(ctx context.Context, key K, offset int64, val string) (newLen int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L157-L170
 	panic("encore apps must be run using the encore command")
 }
 
@@ -133,6 +205,12 @@ func (*StringKeyspace[K]) SetRange(ctx context.Context, key K, offset int64, val
 //
 // See https://redis.io/commands/strlen/ for more information.
 func (*StringKeyspace[K]) Len(ctx context.Context, key K) (length int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L177-L188
 	panic("encore apps must be run using the encore command")
 }
 
@@ -141,6 +219,12 @@ func (*StringKeyspace[K]) Len(ctx context.Context, key K) (length int64, err err
 // The type parameter K specifies the key type, which can either be a
 // named struct type or a basic type (string, int, etc).
 func NewIntKeyspace[K any](cluster *Cluster, cfg KeyspaceConfig) *IntKeyspace[K] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L194-L203
 	panic("encore apps must be run using the encore command")
 }
 
@@ -156,6 +240,12 @@ type IntKeyspace[K any] struct {
 //
 //	myKeyspace.With(cache.ExpireIn(3 * time.Second)).Set(...)
 func (*IntKeyspace[K]) With(opts ...WriteOption) *IntKeyspace[K] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L215-L217
 	panic("encore apps must be run using the encore command")
 }
 
@@ -164,6 +254,12 @@ func (*IntKeyspace[K]) With(opts ...WriteOption) *IntKeyspace[K] {
 //
 // See https://redis.io/commands/get/ for more information.
 func (*IntKeyspace[K]) Get(ctx context.Context, key K) (int64, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L223-L225
 	panic("encore apps must be run using the encore command")
 }
 
@@ -171,6 +267,12 @@ func (*IntKeyspace[K]) Get(ctx context.Context, key K) (int64, error) {
 //
 // See https://redis.io/commands/set/ for more information.
 func (*IntKeyspace[K]) Set(ctx context.Context, key K, val int64) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L230-L232
 	panic("encore apps must be run using the encore command")
 }
 
@@ -179,6 +281,12 @@ func (*IntKeyspace[K]) Set(ctx context.Context, key K, val int64) error {
 //
 // See https://redis.io/commands/setnx/ for more information.
 func (*IntKeyspace[K]) SetIfNotExists(ctx context.Context, key K, val int64) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L238-L240
 	panic("encore apps must be run using the encore command")
 }
 
@@ -187,6 +295,12 @@ func (*IntKeyspace[K]) SetIfNotExists(ctx context.Context, key K, val int64) err
 //
 // See https://redis.io/commands/set/ for more information.
 func (*IntKeyspace[K]) Replace(ctx context.Context, key K, val int64) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L246-L248
 	panic("encore apps must be run using the encore command")
 }
 
@@ -195,6 +309,12 @@ func (*IntKeyspace[K]) Replace(ctx context.Context, key K, val int64) error {
 //
 // See https://redis.io/commands/getset/ for more information.
 func (*IntKeyspace[K]) GetAndSet(ctx context.Context, key K, val int64) (oldVal int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L254-L256
 	panic("encore apps must be run using the encore command")
 }
 
@@ -203,6 +323,12 @@ func (*IntKeyspace[K]) GetAndSet(ctx context.Context, key K, val int64) (oldVal 
 //
 // See https://redis.io/commands/getdel/ for more information.
 func (*IntKeyspace[K]) GetAndDelete(ctx context.Context, key K) (oldVal int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L262-L264
 	panic("encore apps must be run using the encore command")
 }
 
@@ -214,6 +340,12 @@ func (*IntKeyspace[K]) GetAndDelete(ctx context.Context, key K) (oldVal int64, e
 //
 // See https://redis.io/commands/del/ for more information.
 func (*IntKeyspace[K]) Delete(ctx context.Context, keys ...K) (deleted int, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L273-L275
 	panic("encore apps must be run using the encore command")
 }
 
@@ -228,6 +360,12 @@ func (*IntKeyspace[K]) Delete(ctx context.Context, keys ...K) (deleted int, err 
 //
 // See https://redis.io/commands/incrby/ for more information.
 func (*IntKeyspace[K]) Increment(ctx context.Context, key K, delta int64) (newVal int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L287-L300
 	panic("encore apps must be run using the encore command")
 }
 
@@ -242,6 +380,12 @@ func (*IntKeyspace[K]) Increment(ctx context.Context, key K, delta int64) (newVa
 //
 // See https://redis.io/commands/decrby/ for more information.
 func (*IntKeyspace[K]) Decrement(ctx context.Context, key K, delta int64) (newVal int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L312-L326
 	panic("encore apps must be run using the encore command")
 }
 
@@ -250,6 +394,12 @@ func (*IntKeyspace[K]) Decrement(ctx context.Context, key K, delta int64) (newVa
 // The type parameter K specifies the key type, which can either be a
 // named struct type or a basic type (string, int, etc).
 func NewFloatKeyspace[K any](cluster *Cluster, cfg KeyspaceConfig) *FloatKeyspace[K] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L332-L341
 	panic("encore apps must be run using the encore command")
 }
 
@@ -265,6 +415,12 @@ type FloatKeyspace[K any] struct {
 //
 //	myKeyspace.With(cache.ExpireIn(3 * time.Second)).Set(...)
 func (*FloatKeyspace[K]) With(opts ...WriteOption) *FloatKeyspace[K] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L353-L355
 	panic("encore apps must be run using the encore command")
 }
 
@@ -273,6 +429,12 @@ func (*FloatKeyspace[K]) With(opts ...WriteOption) *FloatKeyspace[K] {
 //
 // See https://redis.io/commands/get/ for more information.
 func (*FloatKeyspace[K]) Get(ctx context.Context, key K) (float64, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L361-L363
 	panic("encore apps must be run using the encore command")
 }
 
@@ -280,6 +442,12 @@ func (*FloatKeyspace[K]) Get(ctx context.Context, key K) (float64, error) {
 //
 // See https://redis.io/commands/set/ for more information.
 func (*FloatKeyspace[K]) Set(ctx context.Context, key K, val float64) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L368-L370
 	panic("encore apps must be run using the encore command")
 }
 
@@ -288,6 +456,12 @@ func (*FloatKeyspace[K]) Set(ctx context.Context, key K, val float64) error {
 //
 // See https://redis.io/commands/setnx/ for more information.
 func (*FloatKeyspace[K]) SetIfNotExists(ctx context.Context, key K, val float64) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L376-L378
 	panic("encore apps must be run using the encore command")
 }
 
@@ -296,6 +470,12 @@ func (*FloatKeyspace[K]) SetIfNotExists(ctx context.Context, key K, val float64)
 //
 // See https://redis.io/commands/set/ for more information.
 func (*FloatKeyspace[K]) Replace(ctx context.Context, key K, val float64) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L384-L386
 	panic("encore apps must be run using the encore command")
 }
 
@@ -304,6 +484,12 @@ func (*FloatKeyspace[K]) Replace(ctx context.Context, key K, val float64) error 
 //
 // See https://redis.io/commands/getset/ for more information.
 func (*FloatKeyspace[K]) GetAndSet(ctx context.Context, key K, val float64) (oldVal float64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L392-L394
 	panic("encore apps must be run using the encore command")
 }
 
@@ -312,6 +498,12 @@ func (*FloatKeyspace[K]) GetAndSet(ctx context.Context, key K, val float64) (old
 //
 // See https://redis.io/commands/getdel/ for more information.
 func (*FloatKeyspace[K]) GetAndDelete(ctx context.Context, key K) (oldVal float64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L400-L402
 	panic("encore apps must be run using the encore command")
 }
 
@@ -323,6 +515,12 @@ func (*FloatKeyspace[K]) GetAndDelete(ctx context.Context, key K) (oldVal float6
 //
 // See https://redis.io/commands/del/ for more information.
 func (*FloatKeyspace[K]) Delete(ctx context.Context, keys ...K) (deleted int, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L411-L413
 	panic("encore apps must be run using the encore command")
 }
 
@@ -337,6 +535,12 @@ func (*FloatKeyspace[K]) Delete(ctx context.Context, keys ...K) (deleted int, er
 //
 // See https://redis.io/commands/incrbyfloat/ for more information.
 func (*FloatKeyspace[K]) Increment(ctx context.Context, key K, delta float64) (newVal float64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L425-L438
 	panic("encore apps must be run using the encore command")
 }
 
@@ -351,5 +555,11 @@ func (*FloatKeyspace[K]) Increment(ctx context.Context, key K, delta float64) (n
 //
 // See https://redis.io/commands/incrbyfloat/ for more information.
 func (*FloatKeyspace[K]) Decrement(ctx context.Context, key K, delta float64) (newVal float64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/basic.go#L450-L463
 	panic("encore apps must be run using the encore command")
 }

--- a/storage/cache/cache.go
+++ b/storage/cache/cache.go
@@ -95,10 +95,22 @@ type OpError struct {
 }
 
 func (*OpError) Error() string {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/cache.go#L120-L122
 	panic("encore apps must be run using the encore command")
 }
 
 func (*OpError) Unwrap() error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/cache.go#L124-L126
 	panic("encore apps must be run using the encore command")
 }
 
@@ -127,12 +139,24 @@ func (ExpiryFunc) writeOption() {}
 
 // ExpireIn returns an ExpiryFunc that expires keys after a constant duration.
 func ExpireIn(dur time.Duration) ExpiryFunc {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/cache.go#L166-L168
 	panic("encore apps must be run using the encore command")
 }
 
 // ExpireDailyAt returns an ExpiryFunc that expires keys daily at the given time of day in loc.
 // ExpireDailyAt panics if loc is nil.
 func ExpireDailyAt(hour, minute, second int, loc *time.Location) ExpiryFunc {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/cache.go#L172-L182
 	panic("encore apps must be run using the encore command")
 }
 

--- a/storage/cache/list.go
+++ b/storage/cache/list.go
@@ -18,6 +18,12 @@ type BasicType interface {
 // The type parameter V specifies the value type, which is the type
 // of the elements in each list. It must be a basic type (string, int, int64, or float64).
 func NewListKeyspace[K any, V BasicType](cluster *Cluster, cfg KeyspaceConfig) *ListKeyspace[K, V] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L25-L32
 	panic("encore apps must be run using the encore command")
 }
 
@@ -34,6 +40,12 @@ type ListKeyspace[K any, V BasicType] struct {
 //
 //	myKeyspace.With(cache.ExpireIn(3 * time.Second)).Set(...)
 func (*ListKeyspace[K, V]) With(opts ...WriteOption) *ListKeyspace[K, V] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L45-L47
 	panic("encore apps must be run using the encore command")
 }
 
@@ -45,6 +57,12 @@ func (*ListKeyspace[K, V]) With(opts ...WriteOption) *ListKeyspace[K, V] {
 //
 // See https://redis.io/commands/del/ for more information.
 func (*ListKeyspace[K, V]) Delete(ctx context.Context, keys ...K) (deleted int, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L56-L58
 	panic("encore apps must be run using the encore command")
 }
 
@@ -61,6 +79,12 @@ func (*ListKeyspace[K, V]) Delete(ctx context.Context, keys ...K) (deleted int, 
 //
 // See https://redis.io/commands/lpush/ for more information.
 func (*ListKeyspace[K, V]) PushLeft(ctx context.Context, key K, values ...V) (newLen int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L70-L85
 	panic("encore apps must be run using the encore command")
 }
 
@@ -77,6 +101,12 @@ func (*ListKeyspace[K, V]) PushLeft(ctx context.Context, key K, values ...V) (ne
 //
 // See https://redis.io/commands/rpush/ for more information.
 func (*ListKeyspace[K, V]) PushRight(ctx context.Context, key K, values ...V) (newLen int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L97-L112
 	panic("encore apps must be run using the encore command")
 }
 
@@ -85,6 +115,12 @@ func (*ListKeyspace[K, V]) PushRight(ctx context.Context, key K, values ...V) (n
 //
 // See https://redis.io/commands/lpop/ for more information.
 func (*ListKeyspace[K, V]) PopLeft(ctx context.Context, key K) (val V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L118-L135
 	panic("encore apps must be run using the encore command")
 }
 
@@ -93,6 +129,12 @@ func (*ListKeyspace[K, V]) PopLeft(ctx context.Context, key K) (val V, err error
 //
 // See https://redis.io/commands/rpop/ for more information.
 func (*ListKeyspace[K, V]) PopRight(ctx context.Context, key K) (val V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L141-L157
 	panic("encore apps must be run using the encore command")
 }
 
@@ -102,6 +144,12 @@ func (*ListKeyspace[K, V]) PopRight(ctx context.Context, key K) (val V, err erro
 //
 // See https://redis.io/commands/llen/ for more information.
 func (*ListKeyspace[K, V]) Len(ctx context.Context, key K) (length int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L164-L175
 	panic("encore apps must be run using the encore command")
 }
 
@@ -116,6 +164,12 @@ func (*ListKeyspace[K, V]) Len(ctx context.Context, key K) (length int64, err er
 //
 // See https://redis.io/commands/ltrim/ for more information.
 func (*ListKeyspace[K, V]) Trim(ctx context.Context, key K, start, stop int64) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L187-L198
 	panic("encore apps must be run using the encore command")
 }
 
@@ -128,6 +182,12 @@ func (*ListKeyspace[K, V]) Trim(ctx context.Context, key K, start, stop int64) e
 //
 // See https://redis.io/commands/lset/ for more information.
 func (*ListKeyspace[K, V]) Set(ctx context.Context, key K, idx int64, val V) (err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L208-L220
 	panic("encore apps must be run using the encore command")
 }
 
@@ -140,6 +200,12 @@ func (*ListKeyspace[K, V]) Set(ctx context.Context, key K, idx int64, val V) (er
 //
 // See https://redis.io/commands/lget/ for more information.
 func (*ListKeyspace[K, V]) Get(ctx context.Context, key K, idx int64) (val V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L230-L244
 	panic("encore apps must be run using the encore command")
 }
 
@@ -149,6 +215,12 @@ func (*ListKeyspace[K, V]) Get(ctx context.Context, key K, idx int64) (val V, er
 //
 // See https://redis.io/commands/lrange/ for more information.
 func (*ListKeyspace[K, V]) Items(ctx context.Context, key K) ([]V, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L251-L253
 	panic("encore apps must be run using the encore command")
 }
 
@@ -161,6 +233,12 @@ func (*ListKeyspace[K, V]) Items(ctx context.Context, key K) ([]V, error) {
 //
 // See https://redis.io/commands/lrange/ for more information.
 func (*ListKeyspace[K, V]) GetRange(ctx context.Context, key K, start, stop int64) ([]V, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L263-L265
 	panic("encore apps must be run using the encore command")
 }
 
@@ -173,6 +251,12 @@ func (*ListKeyspace[K, V]) GetRange(ctx context.Context, key K, start, stop int6
 //
 // See https://redis.io/commands/linsert/ for more information.
 func (*ListKeyspace[K, V]) InsertBefore(ctx context.Context, key K, needle, newVal V) (newLen int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L297-L313
 	panic("encore apps must be run using the encore command")
 }
 
@@ -185,6 +269,12 @@ func (*ListKeyspace[K, V]) InsertBefore(ctx context.Context, key K, needle, newV
 //
 // See https://redis.io/commands/linsert/ for more information.
 func (*ListKeyspace[K, V]) InsertAfter(ctx context.Context, key K, needle, newVal V) (newLen int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L323-L339
 	panic("encore apps must be run using the encore command")
 }
 
@@ -196,6 +286,12 @@ func (*ListKeyspace[K, V]) InsertAfter(ctx context.Context, key K, needle, newVa
 //
 // See https://redis.io/commands/lrem/ for more information.
 func (*ListKeyspace[K, V]) RemoveAll(ctx context.Context, key K, needle V) (removed int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L348-L361
 	panic("encore apps must be run using the encore command")
 }
 
@@ -207,6 +303,12 @@ func (*ListKeyspace[K, V]) RemoveAll(ctx context.Context, key K, needle V) (remo
 //
 // See https://redis.io/commands/lrem/ for more information.
 func (*ListKeyspace[K, V]) RemoveFirst(ctx context.Context, key K, count int64, needle V) (removed int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L370-L390
 	panic("encore apps must be run using the encore command")
 }
 
@@ -218,6 +320,12 @@ func (*ListKeyspace[K, V]) RemoveFirst(ctx context.Context, key K, count int64, 
 //
 // See https://redis.io/commands/lrem/ for more information.
 func (*ListKeyspace[K, V]) RemoveLast(ctx context.Context, key K, count int64, needle V) (removed int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L399-L419
 	panic("encore apps must be run using the encore command")
 }
 
@@ -238,5 +346,11 @@ const (
 // If src and dst are the same list, the value is atomically rotated from one end to the other when fromPos != toPos,
 // or if fromPos == toPos nothing happens.
 func (*ListKeyspace[K, V]) Move(ctx context.Context, src, dst K, fromPos, toPos ListPos) (moved V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/list.go#L437-L455
 	panic("encore apps must be run using the encore command")
 }

--- a/storage/cache/pkgfn.go
+++ b/storage/cache/pkgfn.go
@@ -4,5 +4,11 @@ package cache
 //
 // See https://encore.dev/docs/develop/caching for more information.
 func NewCluster(name string, cfg ClusterConfig) *Cluster {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/pkgfn.go#L11-L17
 	panic("encore apps must be run using the encore command")
 }

--- a/storage/cache/set.go
+++ b/storage/cache/set.go
@@ -12,6 +12,12 @@ import (
 // The type parameter V specifies the value type, which is the type
 // of the elements in each set. It must be a basic type (string, int, int64, or float64).
 func NewSetKeyspace[K any, V BasicType](cluster *Cluster, cfg KeyspaceConfig) *SetKeyspace[K, V] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L17-L24
 	panic("encore apps must be run using the encore command")
 }
 
@@ -28,6 +34,12 @@ type SetKeyspace[K any, V BasicType] struct {
 //
 //	myKeyspace.With(cache.ExpireIn(3 * time.Second)).Set(...)
 func (*SetKeyspace[K, V]) With(opts ...WriteOption) *SetKeyspace[K, V] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L37-L39
 	panic("encore apps must be run using the encore command")
 }
 
@@ -39,6 +51,12 @@ func (*SetKeyspace[K, V]) With(opts ...WriteOption) *SetKeyspace[K, V] {
 //
 // See https://redis.io/commands/del/ for more information.
 func (*SetKeyspace[K, V]) Delete(ctx context.Context, keys ...K) (deleted int, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L48-L50
 	panic("encore apps must be run using the encore command")
 }
 
@@ -50,6 +68,12 @@ func (*SetKeyspace[K, V]) Delete(ctx context.Context, keys ...K) (deleted int, e
 //
 // See https://redis.io/commands/sadd/ for more information.
 func (*SetKeyspace[K, V]) Add(ctx context.Context, key K, values ...V) (added int, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L59-L74
 	panic("encore apps must be run using the encore command")
 }
 
@@ -62,6 +86,12 @@ func (*SetKeyspace[K, V]) Add(ctx context.Context, key K, values ...V) (added in
 //
 // See https://redis.io/commands/srem/ for more information.
 func (*SetKeyspace[K, V]) Remove(ctx context.Context, key K, values ...V) (removed int, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L84-L99
 	panic("encore apps must be run using the encore command")
 }
 
@@ -71,6 +101,12 @@ func (*SetKeyspace[K, V]) Remove(ctx context.Context, key K, values ...V) (remov
 //
 // See https://redis.io/commands/spop/ for more information.
 func (*SetKeyspace[K, V]) PopOne(ctx context.Context, key K) (val V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L106-L123
 	panic("encore apps must be run using the encore command")
 }
 
@@ -81,6 +117,12 @@ func (*SetKeyspace[K, V]) PopOne(ctx context.Context, key K) (val V, err error) 
 //
 // See https://redis.io/commands/spop/ for more information.
 func (*SetKeyspace[K, V]) Pop(ctx context.Context, key K, count int) (values []V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L131-L148
 	panic("encore apps must be run using the encore command")
 }
 
@@ -90,6 +132,12 @@ func (*SetKeyspace[K, V]) Pop(ctx context.Context, key K, count int) (values []V
 //
 // See https://redis.io/commands/sismember/ for more information.
 func (*SetKeyspace[K, V]) Contains(ctx context.Context, key K, val V) (contains bool, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L155-L166
 	panic("encore apps must be run using the encore command")
 }
 
@@ -99,6 +147,12 @@ func (*SetKeyspace[K, V]) Contains(ctx context.Context, key K, val V) (contains 
 //
 // See https://redis.io/commands/slen/ for more information.
 func (*SetKeyspace[K, V]) Len(ctx context.Context, key K) (length int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L173-L184
 	panic("encore apps must be run using the encore command")
 }
 
@@ -108,6 +162,12 @@ func (*SetKeyspace[K, V]) Len(ctx context.Context, key K) (length int64, err err
 //
 // See https://redis.io/commands/smembers/ for more information.
 func (*SetKeyspace[K, V]) Items(ctx context.Context, key K) (values []V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L191-L203
 	panic("encore apps must be run using the encore command")
 }
 
@@ -117,6 +177,12 @@ func (*SetKeyspace[K, V]) Items(ctx context.Context, key K) (values []V, err err
 //
 // See https://redis.io/commands/smembers/ for more information.
 func (*SetKeyspace[K, V]) ItemsMap(ctx context.Context, key K) (values map[V]struct{}, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L210-L223
 	panic("encore apps must be run using the encore command")
 }
 
@@ -131,6 +197,12 @@ func (*SetKeyspace[K, V]) ItemsMap(ctx context.Context, key K) (values map[V]str
 //
 // See https://redis.io/commands/sdiff/ for more information.
 func (*SetKeyspace[K, V]) Diff(ctx context.Context, keys ...K) ([]V, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L241-L248
 	panic("encore apps must be run using the encore command")
 }
 
@@ -138,6 +210,12 @@ func (*SetKeyspace[K, V]) Diff(ctx context.Context, keys ...K) ([]V, error) {
 //
 // See https://redis.io/commands/sdiff/ for more information.
 func (*SetKeyspace[K, V]) DiffMap(ctx context.Context, keys ...K) (map[V]struct{}, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L253-L260
 	panic("encore apps must be run using the encore command")
 }
 
@@ -147,6 +225,12 @@ func (*SetKeyspace[K, V]) DiffMap(ctx context.Context, keys ...K) (map[V]struct{
 //
 // See https://redis.io/commands/sdiffstore/ for more information.
 func (*SetKeyspace[K, V]) DiffStore(ctx context.Context, destination K, keys ...K) (size int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L281-L300
 	panic("encore apps must be run using the encore command")
 }
 
@@ -161,6 +245,12 @@ func (*SetKeyspace[K, V]) DiffStore(ctx context.Context, destination K, keys ...
 //
 // See https://redis.io/commands/sinter/ for more information.
 func (*SetKeyspace[K, V]) Intersect(ctx context.Context, keys ...K) ([]V, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L312-L319
 	panic("encore apps must be run using the encore command")
 }
 
@@ -168,6 +258,12 @@ func (*SetKeyspace[K, V]) Intersect(ctx context.Context, keys ...K) ([]V, error)
 //
 // See https://redis.io/commands/sinter/ for more information.
 func (*SetKeyspace[K, V]) IntersectMap(ctx context.Context, keys ...K) (map[V]struct{}, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L324-L331
 	panic("encore apps must be run using the encore command")
 }
 
@@ -177,6 +273,12 @@ func (*SetKeyspace[K, V]) IntersectMap(ctx context.Context, keys ...K) (map[V]st
 //
 // See https://redis.io/commands/sinterstore/ for more information.
 func (*SetKeyspace[K, V]) IntersectStore(ctx context.Context, destination K, keys ...K) (size int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L353-L370
 	panic("encore apps must be run using the encore command")
 }
 
@@ -190,6 +292,12 @@ func (*SetKeyspace[K, V]) IntersectStore(ctx context.Context, destination K, key
 //
 // See https://redis.io/commands/sunion/ for more information.
 func (*SetKeyspace[K, V]) Union(ctx context.Context, keys ...K) ([]V, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L381-L388
 	panic("encore apps must be run using the encore command")
 }
 
@@ -197,6 +305,12 @@ func (*SetKeyspace[K, V]) Union(ctx context.Context, keys ...K) ([]V, error) {
 //
 // See https://redis.io/commands/sunion/ for more information.
 func (*SetKeyspace[K, V]) UnionMap(ctx context.Context, keys ...K) (map[V]struct{}, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L393-L400
 	panic("encore apps must be run using the encore command")
 }
 
@@ -206,6 +320,12 @@ func (*SetKeyspace[K, V]) UnionMap(ctx context.Context, keys ...K) (map[V]struct
 //
 // See https://redis.io/commands/sunionstore/ for more information.
 func (*SetKeyspace[K, V]) UnionStore(ctx context.Context, destination K, keys ...K) (size int64, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L423-L439
 	panic("encore apps must be run using the encore command")
 }
 
@@ -215,6 +335,12 @@ func (*SetKeyspace[K, V]) UnionStore(ctx context.Context, destination K, keys ..
 //
 // See https://redis.io/commands/srandmember/ for more information.
 func (*SetKeyspace[K, V]) SampleOne(ctx context.Context, key K) (val V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L446-L460
 	panic("encore apps must be run using the encore command")
 }
 
@@ -225,6 +351,12 @@ func (*SetKeyspace[K, V]) SampleOne(ctx context.Context, key K) (val V, err erro
 //
 // See https://redis.io/commands/srandmember/ for more information.
 func (*SetKeyspace[K, V]) Sample(ctx context.Context, key K, count int) (values []V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L468-L489
 	panic("encore apps must be run using the encore command")
 }
 
@@ -235,6 +367,12 @@ func (*SetKeyspace[K, V]) Sample(ctx context.Context, key K, count int) (values 
 //
 // See https://redis.io/commands/srandmember/ for more information.
 func (*SetKeyspace[K, V]) SampleWithReplacement(ctx context.Context, key K, count int) (values []V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L497-L518
 	panic("encore apps must be run using the encore command")
 }
 
@@ -246,5 +384,11 @@ func (*SetKeyspace[K, V]) SampleWithReplacement(ctx context.Context, key K, coun
 // If the element already exists in dst it is still removed from src
 // and Move still reports true, nil.
 func (*SetKeyspace[K, V]) Move(ctx context.Context, src, dst K, val V) (moved bool, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/set.go#L527-L540
 	panic("encore apps must be run using the encore command")
 }

--- a/storage/cache/struct.go
+++ b/storage/cache/struct.go
@@ -9,6 +9,12 @@ import "context"
 //
 // The value parameter V specifies the named struct type that should be stored.
 func NewStructKeyspace[K, V any](cluster *Cluster, cfg KeyspaceConfig) *StructKeyspace[K, V] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/struct.go#L11-L27
 	panic("encore apps must be run using the encore command")
 }
 
@@ -24,6 +30,12 @@ type StructKeyspace[K, V any] struct {
 //
 //	myKeyspace.With(cache.ExpireIn(3 * time.Second)).Set(...)
 func (*StructKeyspace[K, V]) With(opts ...WriteOption) *StructKeyspace[K, V] {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/struct.go#L39-L41
 	panic("encore apps must be run using the encore command")
 }
 
@@ -32,6 +44,12 @@ func (*StructKeyspace[K, V]) With(opts ...WriteOption) *StructKeyspace[K, V] {
 //
 // See https://redis.io/commands/get/ for more information.
 func (*StructKeyspace[K, V]) Get(ctx context.Context, key K) (V, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/struct.go#L47-L49
 	panic("encore apps must be run using the encore command")
 }
 
@@ -39,6 +57,12 @@ func (*StructKeyspace[K, V]) Get(ctx context.Context, key K) (V, error) {
 //
 // See https://redis.io/commands/set/ for more information.
 func (*StructKeyspace[K, V]) Set(ctx context.Context, key K, val V) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/struct.go#L54-L56
 	panic("encore apps must be run using the encore command")
 }
 
@@ -47,6 +71,12 @@ func (*StructKeyspace[K, V]) Set(ctx context.Context, key K, val V) error {
 //
 // See https://redis.io/commands/setnx/ for more information.
 func (*StructKeyspace[K, V]) SetIfNotExists(ctx context.Context, key K, val V) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/struct.go#L62-L64
 	panic("encore apps must be run using the encore command")
 }
 
@@ -55,6 +85,12 @@ func (*StructKeyspace[K, V]) SetIfNotExists(ctx context.Context, key K, val V) e
 //
 // See https://redis.io/commands/set/ for more information.
 func (*StructKeyspace[K, V]) Replace(ctx context.Context, key K, val V) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/struct.go#L70-L72
 	panic("encore apps must be run using the encore command")
 }
 
@@ -63,6 +99,12 @@ func (*StructKeyspace[K, V]) Replace(ctx context.Context, key K, val V) error {
 //
 // See https://redis.io/commands/getset/ for more information.
 func (*StructKeyspace[K, V]) GetAndSet(ctx context.Context, key K, val V) (oldVal V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/struct.go#L78-L80
 	panic("encore apps must be run using the encore command")
 }
 
@@ -71,6 +113,12 @@ func (*StructKeyspace[K, V]) GetAndSet(ctx context.Context, key K, val V) (oldVa
 //
 // See https://redis.io/commands/getdel/ for more information.
 func (*StructKeyspace[K, V]) GetAndDelete(ctx context.Context, key K) (oldVal V, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/struct.go#L86-L88
 	panic("encore apps must be run using the encore command")
 }
 
@@ -82,5 +130,11 @@ func (*StructKeyspace[K, V]) GetAndDelete(ctx context.Context, key K) (oldVal V,
 //
 // See https://redis.io/commands/del/ for more information.
 func (*StructKeyspace[K, V]) Delete(ctx context.Context, keys ...K) (deleted int, err error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/cache/struct.go#L97-L99
 	panic("encore apps must be run using the encore command")
 }

--- a/storage/sqldb/db.go
+++ b/storage/sqldb/db.go
@@ -12,6 +12,12 @@ type Database struct {
 // Stdlib returns a *sql.DB object that is connected to the same db,
 // for use with libraries that expect a *sql.DB.
 func (*Database) Stdlib() *sql.DB {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/db.go#L46-L77
 	panic("encore apps must be run using the encore command")
 }
 
@@ -20,6 +26,12 @@ func (*Database) Stdlib() *sql.DB {
 //
 // See (*database/sql.DB).ExecContext() for additional documentation.
 func (*Database) Exec(ctx context.Context, query string, args ...interface{}) (ExecResult, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/db.go#L152-L176
 	panic("encore apps must be run using the encore command")
 }
 
@@ -28,6 +40,12 @@ func (*Database) Exec(ctx context.Context, query string, args ...interface{}) (E
 //
 // See (*database/sql.DB).QueryContext() for additional documentation.
 func (*Database) Query(ctx context.Context, query string, args ...interface{}) (*Rows, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/db.go#L182-L209
 	panic("encore apps must be run using the encore command")
 }
 
@@ -35,6 +53,12 @@ func (*Database) Query(ctx context.Context, query string, args ...interface{}) (
 //
 // See (*database/sql.DB).QueryRowContext() for additional documentation.
 func (*Database) QueryRow(ctx context.Context, query string, args ...interface{}) *Row {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/db.go#L214-L239
 	panic("encore apps must be run using the encore command")
 }
 
@@ -42,5 +66,11 @@ func (*Database) QueryRow(ctx context.Context, query string, args ...interface{}
 //
 // See (*database/sql.DB).Begin() for additional documentation.
 func (*Database) Begin(ctx context.Context) (*Tx, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/db.go#L244-L264
 	panic("encore apps must be run using the encore command")
 }

--- a/storage/sqldb/pkgfn.go
+++ b/storage/sqldb/pkgfn.go
@@ -9,6 +9,12 @@ import (
 //
 // See (*database/sql.DB).ExecContext() for additional documentation.
 func Exec(ctx context.Context, query string, args ...interface{}) (ExecResult, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/pkgfn.go#L13-L15
 	panic("encore apps must be run using the encore command")
 }
 
@@ -17,6 +23,12 @@ func Exec(ctx context.Context, query string, args ...interface{}) (ExecResult, e
 //
 // See (*database/sql.DB).QueryContext() for additional documentation.
 func Query(ctx context.Context, query string, args ...interface{}) (*Rows, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/pkgfn.go#L21-L23
 	panic("encore apps must be run using the encore command")
 }
 
@@ -24,6 +36,12 @@ func Query(ctx context.Context, query string, args ...interface{}) (*Rows, error
 //
 // See (*database/sql.DB).QueryRowContext() for additional documentation.
 func QueryRow(ctx context.Context, query string, args ...interface{}) *Row {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/pkgfn.go#L28-L30
 	panic("encore apps must be run using the encore command")
 }
 
@@ -31,6 +49,12 @@ func QueryRow(ctx context.Context, query string, args ...interface{}) *Row {
 //
 // See (*database/sql.DB).Begin() for additional documentation.
 func Begin(ctx context.Context) (*Tx, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/pkgfn.go#L35-L37
 	panic("encore apps must be run using the encore command")
 }
 
@@ -39,6 +63,12 @@ func Begin(ctx context.Context) (*Tx, error) {
 // See (*database/sql.Tx).Commit() for additional documentation.
 // Deprecated: use tx.Commit() instead.
 func Commit(tx *Tx) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/pkgfn.go#L43-L45
 	panic("encore apps must be run using the encore command")
 }
 
@@ -47,6 +77,12 @@ func Commit(tx *Tx) error {
 // See (*database/sql.Tx).Rollback() for additional documentation.
 // Deprecated: use tx.Rollback() instead.
 func Rollback(tx *Tx) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/pkgfn.go#L51-L53
 	panic("encore apps must be run using the encore command")
 }
 
@@ -55,6 +91,12 @@ func Rollback(tx *Tx) error {
 // See (*database/sql.Tx).ExecContext() for additional documentation.
 // Deprecated: use tx.Exec() instead.
 func ExecTx(tx *Tx, ctx context.Context, query string, args ...interface{}) (ExecResult, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/pkgfn.go#L59-L61
 	panic("encore apps must be run using the encore command")
 }
 
@@ -63,6 +105,12 @@ func ExecTx(tx *Tx, ctx context.Context, query string, args ...interface{}) (Exe
 // See (*database/sql.Tx).QueryContext() for additional documentation.
 // Deprecated: use tx.Query() instead.
 func QueryTx(tx *Tx, ctx context.Context, query string, args ...interface{}) (*Rows, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/pkgfn.go#L67-L69
 	panic("encore apps must be run using the encore command")
 }
 
@@ -71,6 +119,12 @@ func QueryTx(tx *Tx, ctx context.Context, query string, args ...interface{}) (*R
 // See (*database/sql.Tx).QueryRowContext() for additional documentation.
 // Deprecated: use tx.QueryRow() instead.
 func QueryRowTx(tx *Tx, ctx context.Context, query string, args ...interface{}) *Row {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/pkgfn.go#L75-L77
 	panic("encore apps must be run using the encore command")
 }
 
@@ -81,5 +135,11 @@ type constStr string
 //
 // The name must be a string literal constant, to facilitate static analysis.
 func Named(name constStr) *Database {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/pkgfn.go#L86-L88
 	panic("encore apps must be run using the encore command")
 }

--- a/storage/sqldb/sqldb.go
+++ b/storage/sqldb/sqldb.go
@@ -29,22 +29,58 @@ type Tx struct {
 // Commit commits the given transaction.
 //
 // See (*database/sql.Tx).Commit() for additional documentation.
-func (*Tx) Commit() error { panic("encore apps must be run using the encore command") }
+func (*Tx) Commit() error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//
+	//	https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L42-L42
+	panic("encore apps must be run using the encore command")
+}
 
 // Rollback rolls back the given transaction.
 //
 // See (*database/sql.Tx).Rollback() for additional documentation.
-func (*Tx) Rollback() error { panic("encore apps must be run using the encore command") }
+func (*Tx) Rollback() error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//
+	//	https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L47-L47
+	panic("encore apps must be run using the encore command")
+}
 
 func (*Tx) Exec(ctx context.Context, query string, args ...interface{}) (ExecResult, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L85-L87
 	panic("encore apps must be run using the encore command")
 }
 
 func (*Tx) Query(ctx context.Context, query string, args ...interface{}) (*Rows, error) {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L114-L140
 	panic("encore apps must be run using the encore command")
 }
 
 func (*Tx) QueryRow(ctx context.Context, query string, args ...interface{}) *Row {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L142-L168
 	panic("encore apps must be run using the encore command")
 }
 
@@ -59,7 +95,16 @@ type Rows struct {
 // Close closes the Rows, preventing further enumeration.
 //
 // See (*database/sql.Rows).Close() for additional documentation.
-func (*Rows) Close() { panic("encore apps must be run using the encore command") }
+func (*Rows) Close() {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//
+	//	https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L181-L181
+	panic("encore apps must be run using the encore command")
+}
 
 // Scan copies the columns in the current row into the values pointed
 // at by dest. The number of values in dest must be the same as the
@@ -67,6 +112,12 @@ func (*Rows) Close() { panic("encore apps must be run using the encore command")
 //
 // See (*database/sql.Rows).Scan() for additional documentation.
 func (*Rows) Scan(dest ...interface{}) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L188-L188
 	panic("encore apps must be run using the encore command")
 }
 
@@ -74,7 +125,16 @@ func (*Rows) Scan(dest ...interface{}) error {
 // Err may be called after an explicit or implicit Close.
 //
 // See (*database/sql.Rows).Err() for additional documentation.
-func (*Rows) Err() error { panic("encore apps must be run using the encore command") }
+func (*Rows) Err() error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//
+	//	https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L194-L194
+	panic("encore apps must be run using the encore command")
+}
 
 // Next prepares the next result row for reading with the Scan method. It
 // returns true on success, or false if there is no next result row or an error
@@ -84,7 +144,16 @@ func (*Rows) Err() error { panic("encore apps must be run using the encore comma
 // Every call to Scan, even the first one, must be preceded by a call to Next.
 //
 // See (*database/sql.Rows).Next() for additional documentation.
-func (*Rows) Next() bool { panic("encore apps must be run using the encore command") }
+func (*Rows) Next() bool {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//
+	//	https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L204-L204
+	panic("encore apps must be run using the encore command")
+}
 
 // Row is the result of calling QueryRow to select a single row.
 //
@@ -98,9 +167,21 @@ type Row struct {
 //
 // See (*database/sql.Row).Scan() for additional documentation.
 func (*Row) Scan(dest ...interface{}) error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L218-L231
 	panic("encore apps must be run using the encore command")
 }
 
 func (*Row) Err() error {
+	// Encore will provide an implementation to this function at runtime, we do not expose
+	// the implementation in the API contract as it is an implementation detail, which may change
+	// between releases.
+	//
+	// The current implementation of this function can be found here:
+	//    https://github.com/encoredev/encore/blob/49a2d858ee8ab00336b162540061e232e9d3f70e/runtime/storage/sqldb/sqldb.go#L233-L238
 	panic("encore apps must be run using the encore command")
 }


### PR DESCRIPTION
This commit adds the new `encore.dev/config` API's to the `encore.dev` module.

It also adds new comments explaining to users why
we panic in this code, and provides a link to go to the current implementation of the given function.

This was generated with the changes made in encoredev/encore#450