### PR TITLE
Update go.mod to remove security vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module encore.dev
 
 go 1.18
 
-require github.com/jackc/pgx/v5 v5.2.0
+require github.com/jackc/pgx/v5 v5.6.0
 
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect


### PR DESCRIPTION
just updating version, no breaking changes, updates indirect dependency golang.org/x/text as v0.3.8 has security vulnerability  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38561